### PR TITLE
depth: add coverage plot generation with mosdepth quantized mode

### DIFF
--- a/AAFTF/AAFTF_main.py
+++ b/AAFTF/AAFTF_main.py
@@ -747,6 +747,36 @@ def main():
         help="Minimum contig length to include in depth outlier analysis (default: 500)",
     )
 
+    parser_depth.add_argument(
+        "--plot-format",
+        choices=["pdf", "svg", "png"],
+        default="pdf",
+        dest="plot_format",
+        help="Output format for coverage plots (default: pdf; requires matplotlib)",
+    )
+
+    parser_depth.add_argument(
+        "--no-plot",
+        action="store_true",
+        dest="no_plot",
+        help="Disable coverage plot generation",
+    )
+
+    parser_depth.add_argument(
+        "--quantize",
+        default="0:1:4:100:200:",
+        dest="quantize",
+        help="mosdepth quantize bin boundaries, colon-separated with trailing colon " "(default: 0:1:4:100:200:)",
+    )
+
+    parser_depth.add_argument(
+        "--quantize-labels",
+        default=None,
+        dest="quantize_labels",
+        metavar="LABELS",
+        help="Comma-separated labels for quantize bins " "(default: NO_COVERAGE,LOW_COVERAGE,CALLABLE,HIGH_COVERAGE,VERY_HIGH_COVERAGE " "for the default bins)",
+    )
+
     ##########
     # pipeline run it all
     ##########

--- a/AAFTF/depth.py
+++ b/AAFTF/depth.py
@@ -5,6 +5,12 @@ minimap2 (or bwa for Illumina reads), then runs mosdepth to compute
 per-contig and whole-assembly coverage statistics.  Contigs with mean
 depth more than 3 standard deviations above the assembly mean are
 flagged as possible contaminants or organelles.
+
+When plotting is enabled (default, requires matplotlib), mosdepth is run in
+quantized mode and three additional plots are produced alongside the report:
+  <prefix>.depth_heatmap.<format>   — per-scaffold coverage-class tiles
+  <prefix>.depth_barplot.<format>   — stacked bar of coverage-class proportions
+  <prefix>.depth_histogram.<format> — histogram + boxplot of per-scaffold depths
 """
 
 import gzip
@@ -15,7 +21,43 @@ import subprocess
 import sys
 import uuid
 
+try:
+    import matplotlib
+
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.backends.backend_pdf import PdfPages
+    from matplotlib.patches import Patch
+
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
 from AAFTF.utility import SafeRemove, checkfile, printCMD, status, which
+
+# ---------------------------------------------------------------------------
+# Constants for quantized coverage classes
+# ---------------------------------------------------------------------------
+
+_DEFAULT_QUANTIZE = "0:1:4:100:200:"
+_DEFAULT_LABELS = [
+    "NO_COVERAGE",
+    "LOW_COVERAGE",
+    "CALLABLE",
+    "HIGH_COVERAGE",
+    "VERY_HIGH_COVERAGE",
+]
+_COV_COLOURS = {
+    "NO_COVERAGE": "#313695",
+    "LOW_COVERAGE": "#74add1",
+    "CALLABLE": "#ffffbf",
+    "HIGH_COVERAGE": "#f46d43",
+    "VERY_HIGH_COVERAGE": "#a50026",
+}
+# Fallback palette for non-standard bin labels
+_FALLBACK_COLOURS = ["#313695", "#74add1", "#ffffbf", "#f46d43", "#a50026", "#762a83", "#1b7837"]
+
+_SCAFFOLDS_PER_PAGE = 50
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -266,6 +308,366 @@ def _coverage_breadth_from_dist(dist_file):
 
 
 # ---------------------------------------------------------------------------
+# Quantized mosdepth helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_quantize_bins(quantize_str, labels_str=None):
+    """Parse a mosdepth quantize string and return bin labels plus env-var dict.
+
+    Args:
+        quantize_str: Colon-separated bin boundaries with trailing colon,
+            e.g. "0:1:4:100:200:".
+        labels_str: Optional comma-separated label names, one per bin.
+            When None, default names are used for the default quantize string;
+            otherwise bins are named BIN_0, BIN_1, etc.
+
+    Returns:
+        Tuple (labels, env_dict) where labels is a list of strings and
+        env_dict maps MOSDEPTH_Q0..QN to the corresponding label strings.
+    """
+    thresholds = [t for t in quantize_str.split(":") if t.strip()]
+    n_bins = len(thresholds)
+
+    if labels_str:
+        labels = [lbl.strip() for lbl in labels_str.split(",")]
+    elif quantize_str == _DEFAULT_QUANTIZE:
+        labels = _DEFAULT_LABELS[:]
+    else:
+        labels = [f"BIN_{i}" for i in range(n_bins)]
+
+    # pad or truncate to match bin count
+    while len(labels) < n_bins:
+        labels.append(f"BIN_{len(labels)}")
+    labels = labels[:n_bins]
+
+    env_dict = {f"MOSDEPTH_Q{i}": labels[i] for i in range(n_bins)}
+    return labels, env_dict
+
+
+def run_mosdepth_quantized(bam_file, workdir, cpus, quantize_str, env_dict, prefix="coverage", debug=False):
+    """Run mosdepth in quantized mode.
+
+    Produces a summary file (same format as run_mosdepth) plus a
+    quantized BED file showing which coverage class each genomic interval
+    belongs to.
+
+    Args:
+        bam_file: Absolute path to the sorted, indexed BAM file.
+        workdir: Directory for mosdepth output files.
+        cpus: Number of CPU threads.
+        quantize_str: Colon-separated quantize boundaries, e.g. "0:1:4:100:200:".
+        env_dict: Dict of MOSDEPTH_Q? env vars to set (label names for BED).
+        prefix: Filename prefix for mosdepth outputs.
+        debug: If True, show mosdepth stderr.
+
+    Returns:
+        Tuple (summary_file, quantized_bed) — paths to the two output files.
+    """
+    devnull = _open_devnull()
+    mosdepth_prefix = os.path.join(os.path.abspath(workdir), prefix)
+    run_env = os.environ.copy()
+    run_env.update(env_dict)
+    cmd = [
+        "mosdepth",
+        "--threads",
+        str(cpus),
+        "--no-abbrev",
+        "-n",
+        "--quantize",
+        quantize_str,
+        mosdepth_prefix,
+        os.path.abspath(bam_file),
+    ]
+    printCMD(cmd)
+    subprocess.run(cmd, stderr=None if debug else devnull, env=run_env)
+    devnull.close()
+    summary_file = mosdepth_prefix + ".mosdepth.summary.txt"
+    quantized_bed = mosdepth_prefix + ".quantized.bed.gz"
+    return summary_file, quantized_bed
+
+
+def _read_quantized_bed(quantized_bed):
+    """Read a mosdepth quantized BED file into a per-contig interval dict.
+
+    Args:
+        quantized_bed: Path to the .quantized.bed.gz file.
+
+    Returns:
+        Dict mapping contig name → list of (start, end, label) tuples
+        in order of appearance.
+    """
+    data = {}
+    opener = gzip.open if quantized_bed.endswith(".gz") else open
+    with opener(quantized_bed, "rt") as fh:
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) < 4:
+                continue
+            chrom = parts[0]
+            start = int(parts[1])
+            end = int(parts[2])
+            label = parts[3]
+            if chrom not in data:
+                data[chrom] = []
+            data[chrom].append((start, end, label))
+    return data
+
+
+def _get_plot_prefix(input_file, report_file):
+    """Derive the output path prefix for plot files.
+
+    Strips .fasta/.fa/.fasta.gz/.fa.gz from the input basename and
+    places the result in the same directory as the report file.
+
+    Args:
+        input_file: Path to the genome assembly FASTA.
+        report_file: Path to the coverage report (used for output directory).
+
+    Returns:
+        String path prefix (no extension).
+    """
+    basename = os.path.basename(input_file)
+    for ext in (".fasta.gz", ".fa.gz", ".fasta", ".fa"):
+        if basename.endswith(ext):
+            basename = basename[: -len(ext)]
+            break
+    else:
+        basename = os.path.splitext(basename)[0]
+    report_dir = os.path.dirname(os.path.abspath(report_file))
+    return os.path.join(report_dir, basename)
+
+
+def _cov_colours_for_labels(labels):
+    """Return a colour dict for the given label list.
+
+    Known labels get their canonical colour; others get sequential fallbacks.
+
+    Args:
+        labels: List of coverage-class label strings.
+
+    Returns:
+        Dict mapping label → hex colour string.
+    """
+    colours = {}
+    fallback_idx = 0
+    for lbl in labels:
+        if lbl in _COV_COLOURS:
+            colours[lbl] = _COV_COLOURS[lbl]
+        else:
+            colours[lbl] = _FALLBACK_COLOURS[fallback_idx % len(_FALLBACK_COLOURS)]
+            fallback_idx += 1
+    return colours
+
+
+# ---------------------------------------------------------------------------
+# Plot helpers
+# ---------------------------------------------------------------------------
+
+
+def _save_figure(fig, path, plot_format):
+    dpi = 150 if plot_format == "png" else None
+    fig.savefig(path, format=plot_format, dpi=dpi, bbox_inches="tight")
+    plt.close(fig)
+
+
+def _plot_coverage_heatmap(contig_data, scaffold_rows, labels, colours, plot_prefix, plot_format):
+    """Write per-scaffold coverage-class heatmap.
+
+    Each scaffold is one horizontal row; regions are coloured by coverage
+    class.  Scaffolds are paginated (_SCAFFOLDS_PER_PAGE per page).
+
+    Args:
+        contig_data: Dict from _read_quantized_bed.
+        scaffold_rows: List of contig dicts from parse_mosdepth_summary
+            (used for scaffold ordering).
+        labels: Ordered list of coverage-class label strings.
+        colours: Dict mapping label → hex colour.
+        plot_prefix: Output path prefix (no extension).
+        plot_format: "pdf", "svg", or "png".
+    """
+    scaffolds = [r["chrom"] for r in scaffold_rows if r["chrom"] in contig_data]
+    if not scaffolds:
+        return
+
+    legend_patches = [Patch(facecolor=colours.get(lbl, "#888888"), label=lbl) for lbl in labels]
+    pages = [scaffolds[i : i + _SCAFFOLDS_PER_PAGE] for i in range(0, len(scaffolds), _SCAFFOLDS_PER_PAGE)]
+
+    def _make_page(page_scaffolds, page_num, total_pages):
+        n = len(page_scaffolds)
+        fig, ax = plt.subplots(figsize=(14, max(4, n * 0.35 + 2)))
+        for row_idx, contig in enumerate(page_scaffolds):
+            for s, e, lbl in contig_data.get(contig, []):
+                ax.broken_barh(
+                    [(s, e - s)],
+                    (row_idx - 0.4, 0.8),
+                    facecolors=colours.get(lbl, "#888888"),
+                    linewidth=0,
+                )
+        ax.set_yticks(range(n))
+        ax.set_yticklabels(page_scaffolds, fontsize=max(5, min(9, 200 // n)))
+        ax.set_xlabel("Genomic position (bp)")
+        title = "Coverage class heatmap"
+        if total_pages > 1:
+            title += f"  [page {page_num}/{total_pages}]"
+        ax.set_title(title)
+        ax.legend(handles=legend_patches, loc="upper right", fontsize=8)
+        fig.tight_layout()
+        return fig
+
+    if plot_format == "pdf":
+        path = plot_prefix + ".depth_heatmap.pdf"
+        with PdfPages(path) as pdf:
+            for i, page in enumerate(pages):
+                fig = _make_page(page, i + 1, len(pages))
+                pdf.savefig(fig)
+                plt.close(fig)
+        status(f"Coverage heatmap written to: {path}")
+    else:
+        for i, page in enumerate(pages):
+            suffix = f"_p{i + 1:02d}" if len(pages) > 1 else ""
+            path = f"{plot_prefix}.depth_heatmap{suffix}.{plot_format}"
+            fig = _make_page(page, i + 1, len(pages))
+            _save_figure(fig, path, plot_format)
+            status(f"Coverage heatmap written to: {path}")
+
+
+def _plot_coverage_barplot(contig_data, scaffold_rows, labels, colours, plot_prefix, plot_format):
+    """Write per-scaffold stacked bar chart of coverage-class proportions.
+
+    Args:
+        contig_data: Dict from _read_quantized_bed.
+        scaffold_rows: List of contig dicts from parse_mosdepth_summary.
+        labels: Ordered list of coverage-class label strings.
+        colours: Dict mapping label → hex colour.
+        plot_prefix: Output path prefix (no extension).
+        plot_format: "pdf", "svg", or "png".
+    """
+    scaffolds = [r["chrom"] for r in scaffold_rows if r["chrom"] in contig_data]
+    if not scaffolds:
+        return
+
+    # Compute per-scaffold percentage of each coverage class
+    pcts = {}
+    for contig in scaffolds:
+        intervals = contig_data.get(contig, [])
+        total_bp = sum(e - s for s, e, _ in intervals)
+        label_bp = {lbl: 0 for lbl in labels}
+        for s, e, lbl in intervals:
+            if lbl in label_bp:
+                label_bp[lbl] += e - s
+        pcts[contig] = {lbl: (label_bp[lbl] / total_bp * 100 if total_bp else 0.0) for lbl in labels}
+
+    legend_patches = [Patch(facecolor=colours.get(lbl, "#888888"), label=lbl) for lbl in labels]
+    pages = [scaffolds[i : i + _SCAFFOLDS_PER_PAGE] for i in range(0, len(scaffolds), _SCAFFOLDS_PER_PAGE)]
+
+    def _make_page(page_scaffolds, page_num, total_pages):
+        n = len(page_scaffolds)
+        fig, ax = plt.subplots(figsize=(12, max(4, n * 0.35 + 2)))
+        # draw bottom-to-top so first scaffold appears at the top
+        display_order = list(reversed(page_scaffolds))
+        for row_idx, contig in enumerate(display_order):
+            left = 0.0
+            for lbl in labels:
+                pct = pcts[contig].get(lbl, 0.0)
+                if pct > 0:
+                    ax.barh(row_idx, pct, left=left, color=colours.get(lbl, "#888888"))
+                left += pct
+        ax.set_yticks(range(n))
+        ax.set_yticklabels(display_order, fontsize=max(5, min(9, 200 // n)))
+        ax.set_xlabel("Percentage of scaffold (bp)")
+        ax.set_xlim(0, 100)
+        title = "Coverage class proportions"
+        if total_pages > 1:
+            title += f"  [page {page_num}/{total_pages}]"
+        ax.set_title(title)
+        ax.legend(handles=legend_patches, loc="lower right", fontsize=8)
+        fig.tight_layout()
+        return fig
+
+    if plot_format == "pdf":
+        path = plot_prefix + ".depth_barplot.pdf"
+        with PdfPages(path) as pdf:
+            for i, page in enumerate(pages):
+                fig = _make_page(page, i + 1, len(pages))
+                pdf.savefig(fig)
+                plt.close(fig)
+        status(f"Coverage barplot written to: {path}")
+    else:
+        for i, page in enumerate(pages):
+            suffix = f"_p{i + 1:02d}" if len(pages) > 1 else ""
+            path = f"{plot_prefix}.depth_barplot{suffix}.{plot_format}"
+            fig = _make_page(page, i + 1, len(pages))
+            _save_figure(fig, path, plot_format)
+            status(f"Coverage barplot written to: {path}")
+
+
+def _plot_depth_histogram(contig_rows, mean_depth, plot_prefix, plot_format):
+    """Write histogram and boxplot of per-scaffold mean coverage depths.
+
+    Args:
+        contig_rows: List of contig dicts from parse_mosdepth_summary.
+        mean_depth: Assembly-wide mean depth (float).
+        plot_prefix: Output path prefix (no extension).
+        plot_format: "pdf", "svg", or "png".
+    """
+    depths = [c["mean"] for c in contig_rows if c.get("mean", 0) > 0]
+    if not depths:
+        return
+
+    # Log-spaced bins for the histogram
+    min_d = max(min(depths), 0.01)
+    max_d = max(depths)
+    log_min = math.log10(min_d)
+    log_max = math.log10(max_d * 1.05)
+    n_bins = min(60, len(depths))
+    step = (log_max - log_min) / n_bins if log_max > log_min else 1.0
+    bins = [10 ** (log_min + i * step) for i in range(n_bins + 1)]
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+
+    # Histogram with log x-axis
+    ax1 = axes[0]
+    ax1.hist(depths, bins=bins, color="#2166ac", alpha=0.75, edgecolor="none")
+    ax1.set_xscale("log")
+    if mean_depth > 0:
+        ax1.axvline(
+            mean_depth,
+            color="red",
+            linestyle="--",
+            linewidth=1,
+            label=f"Mean: {mean_depth:.1f}x",
+        )
+        ax1.legend(fontsize=9)
+    ax1.set_xlabel("Mean depth of coverage (log10 scale)")
+    ax1.set_ylabel("Number of scaffolds")
+    ax1.set_title("Per-scaffold coverage distribution")
+
+    # Boxplot with log y-axis
+    ax2 = axes[1]
+    ax2.boxplot(
+        depths,
+        vert=True,
+        patch_artist=True,
+        boxprops=dict(facecolor="#2166ac", alpha=0.7),
+        medianprops=dict(color="red", linewidth=1.5),
+        flierprops=dict(marker="o", markersize=3, alpha=0.5),
+    )
+    ax2.set_yscale("log")
+    ax2.set_ylabel("Mean depth of coverage (log10 scale)")
+    ax2.set_xticks([1])
+    ax2.set_xticklabels(["All scaffolds"])
+    ax2.set_title("Coverage depth distribution")
+
+    fig.suptitle("Scaffold coverage depth summary", fontsize=12, fontweight="bold")
+    fig.tight_layout()
+
+    path = f"{plot_prefix}.depth_histogram.{plot_format}"
+    _save_figure(fig, path, plot_format)
+    status(f"Depth histogram written to: {path}")
+
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 
@@ -277,6 +679,9 @@ def run(parser, args):
     and whole-assembly depth via mosdepth, and writes a coverage report.
     Contigs with mean depth > (assembly_mean + 3 * SD) are flagged as
     possible contaminants or organellar sequences.
+
+    When plotting is not disabled (--no-plot), mosdepth is run in quantized
+    mode and three coverage plots are produced alongside the text report.
 
     Args:
         parser: ArgumentParser instance (kept for CLI signature compatibility).
@@ -315,6 +720,16 @@ def run(parser, args):
         if not which(tool):
             status(f"ERROR: required tool '{tool}' not found in PATH. " f"Install via conda: conda install -c bioconda {tool}")
             sys.exit(1)
+
+    no_plot = getattr(args, "no_plot", False)
+    plot_format = getattr(args, "plot_format", "pdf")
+    quantize_str = getattr(args, "quantize", _DEFAULT_QUANTIZE)
+    quantize_labels_str = getattr(args, "quantize_labels", None)
+
+    if not no_plot and not HAS_MATPLOTLIB:
+        status("WARNING: matplotlib not available — coverage plots will be skipped.")
+        status("         Install with: conda install -c conda-forge matplotlib")
+        no_plot = True
 
     # ------------------------------------------------------------------
     # Working directory
@@ -373,15 +788,31 @@ def run(parser, args):
     flagstat_longreads = run_flagstat(bam_longreads) if bam_longreads else None
 
     # ------------------------------------------------------------------
-    # mosdepth
+    # mosdepth (quantized when plotting is enabled, standard otherwise)
     # ------------------------------------------------------------------
     status("Running mosdepth...")
-    summary_file = run_mosdepth(
-        bam_combined,
-        workdir,
-        args.cpus,
-        debug=args.debug,
-    )
+    quantized_bed = None
+    labels = None
+    colours = None
+    if not no_plot:
+        labels, env_dict = _parse_quantize_bins(quantize_str, quantize_labels_str)
+        colours = _cov_colours_for_labels(labels)
+        summary_file, quantized_bed = run_mosdepth_quantized(
+            bam_combined,
+            workdir,
+            args.cpus,
+            quantize_str,
+            env_dict,
+            debug=args.debug,
+        )
+    else:
+        summary_file = run_mosdepth(
+            bam_combined,
+            workdir,
+            args.cpus,
+            debug=args.debug,
+        )
+
     if not os.path.exists(summary_file):
         status(f"ERROR: mosdepth summary not produced: {summary_file}")
         sys.exit(1)
@@ -471,6 +902,18 @@ def run(parser, args):
             fout.write(f"  {c['chrom']:<{cw[0]}} " f"{c['length']:>{cw[1]},} " f"{c['mean']:>{cw[2]}.2f}  {flag}\n")
 
     status(f"Coverage report written to: {report_file}")
+
+    # ------------------------------------------------------------------
+    # Coverage plots
+    # ------------------------------------------------------------------
+    if quantized_bed and os.path.exists(quantized_bed):
+        status("Reading quantized coverage BED...")
+        contig_data = _read_quantized_bed(quantized_bed)
+        plot_prefix = _get_plot_prefix(args.input, args.out)
+        status("Generating coverage plots...")
+        _plot_coverage_heatmap(contig_data, contig_rows_sorted, labels, colours, plot_prefix, plot_format)
+        _plot_coverage_barplot(contig_data, contig_rows_sorted, labels, colours, plot_prefix, plot_format)
+        _plot_depth_histogram(contig_rows, mean_depth, plot_prefix, plot_format)
 
     # ------------------------------------------------------------------
     # Cleanup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Key `args` attributes accessed by each `run()` function:
 - **polish**: `method`, `memory`, `cpus`, `left`, `right`, `longreads`, `workdir`, `infile`, `outfile`, `iterations`, `debug`, `diploid`, `ploidy`, `pipe`, `polca`, `trimmomatic`
 - **sort**: `input`, `minlen`, `out`, `name`
 - **assess**: `input`, `report`, `telomere_monomer`, `telomere_n_repeat`, `telomere_window`
-- **depth**: `input`, `out`, `left`, `right`, `longreads`, `illumina_preset`, `longread_preset`, `aligner`, `cpus`, `workdir`, `debug`, `pipe`, `min_contig_len`
+- **depth**: `input`, `out`, `left`, `right`, `longreads`, `illumina_preset`, `longread_preset`, `aligner`, `cpus`, `workdir`, `debug`, `pipe`, `min_contig_len`, `no_plot`, `plot_format`, `quantize`, `quantize_labels`
 - **mito**: `workdir`, `left`, `right`, `seed`, `reference`, `minlen`, `maxlen`, `out`, `starting`, `pipe`
 - **fix_tbl**: `table`, `report`, `output`, `debug`, `pipe`
 
@@ -111,7 +111,7 @@ Expected inputs/outputs per step:
 5. Parses `mosdepth.summary.txt` for per-contig mean depths and `mosdepth.global.dist.txt` for coverage breadth
 6. Flags contigs with mean depth > assembly_mean + 3×SD as possible contaminants/organelles (uses population SD; contigs are the full assembly population, not a sample)
 
-**Key `args` attributes:** `input`, `out`, `left`, `right`, `longreads`, `illumina_preset`, `longread_preset`, `aligner`, `cpus`, `workdir`, `debug`, `pipe`, `min_contig_len`
+**Key `args` attributes:** `input`, `out`, `left`, `right`, `longreads`, `illumina_preset`, `longread_preset`, `aligner`, `cpus`, `workdir`, `debug`, `pipe`, `min_contig_len`, `no_plot`, `plot_format`, `quantize`, `quantize_labels`
 
 ## Audit Fixes (2026-05-02)
 

--- a/environment.yml
+++ b/environment.yml
@@ -18,6 +18,8 @@ dependencies:
   - fastp
   - novoplasty
   - bbmap
+  - mosdepth
+  - matplotlib
   - ncbi-fcs-gx
   - masurca
   - nextpolish

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -232,6 +232,42 @@ class TestDepthParser:
         # alias 'coverage' routes to depth; same Namespace structure
         assert args.input == "g.fa"
 
+    def test_default_plot_format_is_pdf(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq"])
+        assert args.plot_format == "pdf"
+
+    def test_plot_format_svg(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq", "--plot-format", "svg"])
+        assert args.plot_format == "svg"
+
+    def test_plot_format_png(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq", "--plot-format", "png"])
+        assert args.plot_format == "png"
+
+    def test_no_plot_false_by_default(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq"])
+        assert args.no_plot is False
+
+    def test_no_plot_flag(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq", "--no-plot"])
+        assert args.no_plot is True
+
+    def test_default_quantize(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq"])
+        assert args.quantize == "0:1:4:100:200:"
+
+    def test_custom_quantize(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq", "--quantize", "0:5:50:"])
+        assert args.quantize == "0:5:50:"
+
+    def test_quantize_labels_none_by_default(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq"])
+        assert args.quantize_labels is None
+
+    def test_custom_quantize_labels(self):
+        args = _parse_with_main(["AAFTF", "depth", "-i", "g.fa", "-l", "l.fq", "--quantize-labels", "NONE,LOW,HIGH"])
+        assert args.quantize_labels == "NONE,LOW,HIGH"
+
 
 # ---------------------------------------------------------------------------
 # assess parser — common flags present

--- a/tests/test_depth.py
+++ b/tests/test_depth.py
@@ -1,17 +1,21 @@
 """Unit tests for pure-Python functions in AAFTF/depth.py.
 
-Tests cover FASTQ counting, mosdepth output parsing, and the outlier
-detection arithmetic.  No external tools (minimap2, samtools, mosdepth)
-are required.
+Tests cover FASTQ counting, mosdepth output parsing, outlier detection
+arithmetic, quantize bin parsing, plot prefix derivation, and quantized
+BED reading.  No external tools (minimap2, samtools, mosdepth) are required.
 """
 
 import gzip
 import math
+import os
 
 import pytest
 
 from AAFTF.depth import (
     _coverage_breadth_from_dist,
+    _get_plot_prefix,
+    _parse_quantize_bins,
+    _read_quantized_bed,
     count_fastq_reads,
     parse_mosdepth_summary,
 )
@@ -167,3 +171,170 @@ class TestOutlierDetectionMath:
         assert abs(sd - expected_sd) < 0.01
         assert threshold == pytest.approx(mean + 3 * expected_sd)
         assert 1000.0 in outliers
+
+
+# ---------------------------------------------------------------------------
+# _parse_quantize_bins
+# ---------------------------------------------------------------------------
+
+
+class TestParseQuantizeBins:
+    def test_default_bins_returns_five_labels(self):
+        labels, env_dict = _parse_quantize_bins("0:1:4:100:200:")
+        assert len(labels) == 5
+
+    def test_default_bins_uses_canonical_names(self):
+        labels, _ = _parse_quantize_bins("0:1:4:100:200:")
+        assert labels[0] == "NO_COVERAGE"
+        assert labels[2] == "CALLABLE"
+        assert labels[4] == "VERY_HIGH_COVERAGE"
+
+    def test_env_dict_keys_are_mosdepth_q_vars(self):
+        _, env_dict = _parse_quantize_bins("0:1:4:100:200:")
+        assert set(env_dict.keys()) == {"MOSDEPTH_Q0", "MOSDEPTH_Q1", "MOSDEPTH_Q2", "MOSDEPTH_Q3", "MOSDEPTH_Q4"}
+
+    def test_env_dict_values_match_labels(self):
+        labels, env_dict = _parse_quantize_bins("0:1:4:100:200:")
+        for i, lbl in enumerate(labels):
+            assert env_dict[f"MOSDEPTH_Q{i}"] == lbl
+
+    def test_custom_bins_auto_named(self):
+        labels, _ = _parse_quantize_bins("0:5:50:")
+        assert labels == ["BIN_0", "BIN_1", "BIN_2"]
+
+    def test_custom_labels_override(self):
+        labels, _ = _parse_quantize_bins("0:5:50:", labels_str="NONE,LOW,HIGH")
+        assert labels == ["NONE", "LOW", "HIGH"]
+
+    def test_too_few_custom_labels_get_padded(self):
+        labels, _ = _parse_quantize_bins("0:1:4:100:200:", labels_str="A,B")
+        assert len(labels) == 5
+        assert labels[0] == "A"
+        assert labels[1] == "B"
+        assert labels[2] == "BIN_2"
+
+    def test_too_many_custom_labels_get_truncated(self):
+        labels, _ = _parse_quantize_bins("0:5:", labels_str="X,Y,Z,W")
+        assert labels == ["X", "Y"]
+
+    def test_trailing_colon_not_counted_as_bin(self):
+        labels, _ = _parse_quantize_bins("0:1:")
+        assert len(labels) == 2
+
+    def test_three_bin_custom_string(self):
+        labels, env_dict = _parse_quantize_bins("0:10:100:")
+        assert len(labels) == 3
+        assert "MOSDEPTH_Q2" in env_dict
+
+
+# ---------------------------------------------------------------------------
+# _get_plot_prefix
+# ---------------------------------------------------------------------------
+
+
+class TestGetPlotPrefix:
+    def test_strips_fasta_extension(self, tmp_path):
+        report = str(tmp_path / "coverage_stats.txt")
+        prefix = _get_plot_prefix("genome.fasta", report)
+        assert os.path.basename(prefix) == "genome"
+
+    def test_strips_fa_extension(self, tmp_path):
+        report = str(tmp_path / "coverage_stats.txt")
+        prefix = _get_plot_prefix("assembly.fa", report)
+        assert os.path.basename(prefix) == "assembly"
+
+    def test_strips_fasta_gz_extension(self, tmp_path):
+        report = str(tmp_path / "coverage_stats.txt")
+        prefix = _get_plot_prefix("genome.fasta.gz", report)
+        assert os.path.basename(prefix) == "genome"
+
+    def test_prefix_dir_matches_report_dir(self, tmp_path):
+        report = str(tmp_path / "results" / "coverage_stats.txt")
+        os.makedirs(str(tmp_path / "results"), exist_ok=True)
+        prefix = _get_plot_prefix("genome.fasta", report)
+        assert os.path.dirname(prefix) == str(tmp_path / "results")
+
+    def test_dotted_name_preserves_stem(self, tmp_path):
+        report = str(tmp_path / "coverage_stats.txt")
+        prefix = _get_plot_prefix("strain.final.sorted.fasta", report)
+        assert os.path.basename(prefix) == "strain.final.sorted"
+
+
+# ---------------------------------------------------------------------------
+# _read_quantized_bed
+# ---------------------------------------------------------------------------
+
+
+class TestReadQuantizedBed:
+    def _write_bed(self, path, lines, gz=True):
+        content = "\n".join(lines) + "\n"
+        if gz:
+            with gzip.open(path, "wt") as fh:
+                fh.write(content)
+        else:
+            with open(path, "w") as fh:
+                fh.write(content)
+
+    def test_reads_gzipped_bed(self, tmp_path):
+        bed = str(tmp_path / "test.quantized.bed.gz")
+        self._write_bed(
+            bed,
+            [
+                "scaffold_1\t0\t5000\tNO_COVERAGE",
+                "scaffold_1\t5000\t100000\tCALLABLE",
+                "scaffold_2\t0\t200000\tCALLABLE",
+            ],
+        )
+        data = _read_quantized_bed(bed)
+        assert "scaffold_1" in data
+        assert "scaffold_2" in data
+        assert len(data["scaffold_1"]) == 2
+
+    def test_reads_plain_bed(self, tmp_path):
+        bed = str(tmp_path / "test.quantized.bed")
+        self._write_bed(
+            bed,
+            [
+                "scf1\t0\t1000\tNO_COVERAGE",
+                "scf1\t1000\t5000\tCALLABLE",
+            ],
+            gz=False,
+        )
+        data = _read_quantized_bed(bed)
+        assert len(data["scf1"]) == 2
+
+    def test_interval_fields_parsed_correctly(self, tmp_path):
+        bed = str(tmp_path / "test.quantized.bed.gz")
+        self._write_bed(bed, ["scaffold_1\t100\t500\tHIGH_COVERAGE"])
+        data = _read_quantized_bed(bed)
+        start, end, label = data["scaffold_1"][0]
+        assert start == 100
+        assert end == 500
+        assert label == "HIGH_COVERAGE"
+
+    def test_multiple_contigs_separated(self, tmp_path):
+        bed = str(tmp_path / "test.quantized.bed.gz")
+        self._write_bed(
+            bed,
+            [
+                "chr1\t0\t1000\tCALLABLE",
+                "chr2\t0\t2000\tLOW_COVERAGE",
+                "chr1\t1000\t3000\tHIGH_COVERAGE",
+            ],
+        )
+        data = _read_quantized_bed(bed)
+        assert len(data["chr1"]) == 2
+        assert len(data["chr2"]) == 1
+
+    def test_short_lines_skipped(self, tmp_path):
+        bed = str(tmp_path / "test.quantized.bed.gz")
+        self._write_bed(
+            bed,
+            [
+                "scaffold_1\t0\t1000\tCALLABLE",
+                "bad_line",
+                "scaffold_1\t1000\t2000\tHIGH_COVERAGE",
+            ],
+        )
+        data = _read_quantized_bed(bed)
+        assert len(data["scaffold_1"]) == 2


### PR DESCRIPTION
Add --plot-format {pdf,svg,png}, --no-plot, --quantize, and --quantize-labels flags to the depth subcommand.  When plotting is enabled (default), mosdepth runs in quantized mode (--quantize with dynamic MOSDEPTH_Q? env vars) and three plots are written alongside the coverage report: a per-scaffold coverage-class heatmap, a stacked bar chart of coverage-class proportions, and a log-scale depth histogram with boxplot.  Plots are paginated (50 scaffolds/page) and support PDF (multi-page), SVG, and PNG output.  Falls back gracefully when matplotlib is not installed.  Add matplotlib and mosdepth to environment.yml; add 20 new unit tests (92 total passing).