### PR TITLE
Fix pipeline Namespace bugs, shell injection, and coordinate off-by-ones from code review

### DIFF
--- a/AAFTF/AAFTF_main.py
+++ b/AAFTF/AAFTF_main.py
@@ -160,6 +160,8 @@ def main():
         action="store_true",
         help="Skip downloading NCBI FCS-adaptor resources",
     )
+    parser_download.add_argument("-v", "--debug", action="store_true", help="Provide debugging messages")
+    parser_download.add_argument("--pipe", action="store_true", help="AAFTF is running in pipeline mode")
 
     #########################################
     # create the individual tool parsers

--- a/AAFTF/assess.py
+++ b/AAFTF/assess.py
@@ -127,7 +127,7 @@ def findTelomere(seq, monomer, n, window=200):
     forward, reverse = False, False
 
     # Look for the monomer repeat n number of times.
-    if re.search(monomer * 2, start):
+    if re.search(monomer * n, start):
         forward = True
     rev_monomer = revcomp(monomer)
     if re.search(rev_monomer * n, end):

--- a/AAFTF/depth.py
+++ b/AAFTF/depth.py
@@ -35,7 +35,7 @@ except ImportError:
 
 from packaging.version import Version
 
-from AAFTF.utility import SafeRemove, checkfile, get_samtools_version, printCMD, samtools_sort_cmd, status, which
+from AAFTF.utility import SafeRemove, checkfile, countfastq, get_samtools_version, printCMD, samtools_sort_cmd, status, which
 
 # ---------------------------------------------------------------------------
 # Constants for quantized coverage classes
@@ -76,12 +76,7 @@ def count_fastq_reads(fastq_file):
         Integer count of reads, or -1 on failure.
     """
     try:
-        opener = gzip.open if fastq_file.endswith(".gz") else open
-        n_lines = 0
-        with opener(fastq_file, "rt") as fh:
-            for _ in fh:
-                n_lines += 1
-        return n_lines // 4
+        return countfastq(fastq_file)
     except Exception:
         return -1
 
@@ -169,7 +164,8 @@ def map_reads(genome, reads_left, reads_right, longreads, workdir, cpus, illumin
             if ret.returncode != 0:
                 status("ERROR: bwa index failed")
                 sys.exit(1)
-            map_cmd = ["bwa", "mem", "-t", str(cpus), genome_local, reads_left]
+            read_group = r"@RG\tID:illumina\tSM:illumina\tPL:illumina"
+            map_cmd = ["bwa", "mem", "-t", str(cpus), "-R", read_group, genome_local, reads_left]
             if reads_right:
                 map_cmd.append(reads_right)
         else:

--- a/AAFTF/mito.py
+++ b/AAFTF/mito.py
@@ -45,6 +45,17 @@ def orient_to_start(fasta_in, fasta_out, folder=".", start=False):
             ref_start = int(cols[8]) + ref_offset
         else:
             ref_start = int(cols[7]) - ref_offset
+        if ref_start < 0 or ref_start >= len(initial_seq):
+            # A partial alignment of the seed to the contig edge can push
+            # this offset out of range; Python's negative-index slicing
+            # would silently wrap and produce a bogus rotation instead of
+            # erroring, so treat it the same as a failed rotation.
+            status(f"ERROR: unable to rotate because computed rotation offset {ref_start} is out of range for sequence of length {len(initial_seq)}\n")
+            with open(fasta_out, "w") as outfile:
+                outfile.write(">{}\n{}\n".format("mt", softwrap(initial_seq)))
+            if os.path.isfile(startFile):
+                os.remove(startFile)
+            return
         rotated = initial_seq[ref_start:] + initial_seq[:ref_start]
         if ref_strand == "-":
             rotated = RevComp(rotated)

--- a/AAFTF/mito.py
+++ b/AAFTF/mito.py
@@ -45,7 +45,9 @@ def orient_to_start(fasta_in, fasta_out, folder=".", start=False):
             ref_start = int(cols[8]) + ref_offset
         else:
             ref_start = int(cols[7]) - ref_offset
-        if ref_start < 0 or ref_start >= len(initial_seq):
+        if ref_start == len(initial_seq):
+            ref_start = 0
+        if ref_start < 0 or ref_start > len(initial_seq):
             # A partial alignment of the seed to the contig edge can push
             # this offset out of range; Python's negative-index slicing
             # would silently wrap and produce a bogus rotation instead of

--- a/AAFTF/pipeline.py
+++ b/AAFTF/pipeline.py
@@ -68,11 +68,16 @@ def run(parser, args):
     # run filtering with bbduk
     if not checkfile(basename + "_filtered_1.fastq.gz"):
         filterOpts = ["screen_accessions", "screen_urls", "basename", "cpus", "debug", "memory", "AAFTF_DB", "workdir"]
-        filter_args = create_namespace(filterOpts, required_args={"aligner": "bbduk", "left": basename + "_1P.fastq.gz", "pipe": True})
-        if args.right:
-            filter_args.right = basename + "_2P.fastq.gz"
-        if checkfile(basename + ".mito.fasta"):
-            filter_args.screen_local = [basename + ".mito.fasta"]
+        filter_args = create_namespace(
+            filterOpts,
+            required_args={
+                "aligner": "bbduk",
+                "left": basename + "_1P.fastq.gz",
+                "right": basename + "_2P.fastq.gz" if args.right else None,
+                "screen_local": [basename + ".mito.fasta"] if checkfile(basename + ".mito.fasta") else None,
+                "pipe": True,
+            },
+        )
         aaftf_filter.run(parser, filter_args)
     else:
         if args.right:
@@ -86,13 +91,18 @@ def run(parser, args):
     assembly_file = basename + f".{assembly_method}.fasta"
     if not checkfile(assembly_file):
         assembleOpts = ["memory", "cpus", "debug", "workdir", "method", "assembler_args", "tmpdir"]
-        asm_extra = {"left": basename + "_filtered_1.fastq.gz", "out": assembly_file, "pipe": True, "method": assembly_method, "merged": False}
+        asm_extra = {
+            "left": basename + "_filtered_1.fastq.gz",
+            "right": basename + "_filtered_2.fastq.gz" if args.right else None,
+            "out": assembly_file,
+            "pipe": True,
+            "method": assembly_method,
+            "merged": False,
+        }
         if assembly_method == "spades":
             asm_extra["isolate"] = False
             asm_extra["careful"] = True
         asm_args = create_namespace(assembleOpts, required_args=asm_extra)
-        if args.right:
-            asm_args.right = basename + "_filtered_2.fastq.gz"
         assemble.run(parser, asm_args)
     else:
         status(f"AAFTF assemble output found: {assembly_file}")
@@ -112,9 +122,19 @@ def run(parser, args):
     sourpurge_file = basename + ".sourpurge.fasta"
     if not checkfile(sourpurge_file):
         sourOpts = ["cpus", "debug", "workdir", "AAFTF_DB", "phylum", "sourdb", "mincovpct"]
-        sour_args = create_namespace(sourOpts, required_args={"left": basename + "_filtered_1.fastq.gz", "input": vecscreen_file, "outfile": sourpurge_file, "kmer": 31, "taxonomy": False, "pipe": True, "sourdb_type": "gbk"})
-        if args.right:
-            sour_args.right = basename + "_filtered_2.fastq.gz"
+        sour_args = create_namespace(
+            sourOpts,
+            required_args={
+                "left": basename + "_filtered_1.fastq.gz",
+                "right": basename + "_filtered_2.fastq.gz" if args.right else None,
+                "input": vecscreen_file,
+                "outfile": sourpurge_file,
+                "kmer": 31,
+                "taxonomy": False,
+                "pipe": True,
+                "sourdb_type": "gbk",
+            },
+        )
         sourpurge.run(parser, sour_args)
     else:
         status(f"AAFTF sourpurge output found: {sourpurge_file}")
@@ -134,9 +154,21 @@ def run(parser, args):
     polish_file = basename + ".polish.fasta"
     if not checkfile(polish_file):
         polishOpts = ["cpus", "debug", "workdir", "iterations", "memory"]
-        polish_args = create_namespace(polishOpts, required_args={"infile": rmdup_file, "outfile": polish_file, "left": basename + "_filtered_1.fastq.gz", "pipe": True})
-        if args.right:
-            polish_args.right = basename + "_filtered_2.fastq.gz"
+        polish_args = create_namespace(
+            polishOpts,
+            required_args={
+                "method": "pilon",
+                "infile": rmdup_file,
+                "outfile": polish_file,
+                "left": basename + "_filtered_1.fastq.gz",
+                "right": basename + "_filtered_2.fastq.gz" if args.right else None,
+                "longreads": None,
+                "diploid": False,
+                "ploidy": 1,
+                "polca": "polca.sh",
+                "pipe": True,
+            },
+        )
         polish.run(parser, polish_args)
     else:
         status(f"AAFTF polish output found: {polish_file}")

--- a/AAFTF/rmdup.py
+++ b/AAFTF/rmdup.py
@@ -40,10 +40,11 @@ def run(parser, args):
             if args.debug:
                 print(f"\tquery={qID} hit={tID} pident={pident:.2f} coverage={cov:.2f}")
 
-                if pident > args.percent_id and cov > args.percent_cov:
+            if pident > args.percent_id and cov > args.percent_cov:
+                if args.debug:
                     print(f"{name} duplicated: {pident:.0f}% identity over {cov:.0f}% of the contig. length={qLen}")
-                    garbage = True
-                    break
+                garbage = True
+                break
         return garbage  # false is good, true is repeat
 
     # start here -- functions nested so they can inherit the arguments

--- a/AAFTF/sort.py
+++ b/AAFTF/sort.py
@@ -1,8 +1,5 @@
 """This module sorts FASTA sequences by size and renames headers."""
 
-import operator
-
-from Bio import SeqIO
 from Bio.SeqIO.FastaIO import SimpleFastaParser
 
 from AAFTF.utility import softwrap, status
@@ -16,12 +13,10 @@ def run(parser, args):
         for Header, Seq in SimpleFastaParser(fasta_in):
             if Header not in AllSeqs:
                 if len(Seq) >= args.minlen:
-                    AllSeqs[Header] = len(Seq)
-    sortSeqs = sorted(AllSeqs.items(), key=operator.itemgetter(1), reverse=True)
-    orderedSeqs = [i[0] for i in sortSeqs]
-    SeqRecords = SeqIO.to_dict(SeqIO.parse(args.input, "fasta"))
+                    AllSeqs[Header] = Seq
+    sortSeqs = sorted(AllSeqs.items(), key=lambda item: len(item[1]), reverse=True)
     with open(args.out, "w") as fasta_out:
-        for i, x in enumerate(orderedSeqs):
-            fasta_out.write(f">{args.name}_{i + 1}\n{softwrap(str(SeqRecords[x].seq))}\n")
+        for i, (Header, Seq) in enumerate(sortSeqs):
+            fasta_out.write(f">{args.name}_{i + 1}\n{softwrap(Seq)}\n")
 
     status(f"Output written to: {args.out}")

--- a/AAFTF/sourpurge.py
+++ b/AAFTF/sourpurge.py
@@ -58,7 +58,7 @@ def run(parser, args):
             DB = os.environ["AAFTF_DB"]
         except KeyError:
             if args.AAFTF_DB:
-                SOUR = os.path.join(args.AAFTF_DB, dbfile)
+                DB = args.AAFTF_DB
             else:
                 status(f"$AAFTF_DB/{dbfile} not found, pass --sourdb")
                 sys.exit(1)
@@ -156,27 +156,27 @@ def run(parser, args):
             if revReads:
                 bwa_cmd.append(revReads)
 
-                # run BWA and pipe to samtools sort
-                status("Aligning reads to assembly with BWA")
-                printCMD(bwa_cmd)
-                p1 = subprocess.Popen(bwa_cmd, cwd=args.workdir, stdout=subprocess.PIPE, stderr=DEVNULL)
-                if get_samtools_version() >= Version("1.3"):
-                    # Modern samtools sort reads SAM directly from stdin
-                    sort_cmd = samtools_sort_cmd("-", os.path.join(args.workdir, blobBAM), bamthreads)
-                    printCMD(sort_cmd)
-                    p2 = subprocess.Popen(sort_cmd, stdin=p1.stdout, stderr=DEVNULL)
-                    p1.stdout.close()
-                    p2.communicate()
-                else:
-                    # Older samtools: convert SAM→BAM first, then sort
-                    unsortBAM = os.path.join(args.workdir, "unsorted.bam")
-                    p2 = subprocess.Popen(samtools_view_bam_cmd("-", unsortBAM, bamthreads), cwd=args.workdir, stdin=p1.stdout, stderr=DEVNULL)
-                    p1.stdout.close()
-                    p2.communicate()
-                    subprocess.run(samtools_sort_cmd(unsortBAM, os.path.join(args.workdir, blobBAM), bamthreads), stderr=DEVNULL)
-                    SafeRemove(unsortBAM)
+            # run BWA and pipe to samtools sort
+            status("Aligning reads to assembly with BWA")
+            printCMD(bwa_cmd)
+            p1 = subprocess.Popen(bwa_cmd, cwd=args.workdir, stdout=subprocess.PIPE, stderr=DEVNULL)
+            if get_samtools_version() >= Version("1.3"):
+                # Modern samtools sort reads SAM directly from stdin
+                sort_cmd = samtools_sort_cmd("-", os.path.join(args.workdir, blobBAM), bamthreads)
+                printCMD(sort_cmd)
+                p2 = subprocess.Popen(sort_cmd, stdin=p1.stdout, stderr=DEVNULL)
+                p1.stdout.close()
+                p2.communicate()
+            else:
+                # Older samtools: convert SAM→BAM first, then sort
+                unsortBAM = os.path.join(args.workdir, "unsorted.bam")
+                p2 = subprocess.Popen(samtools_view_bam_cmd("-", unsortBAM, bamthreads), cwd=args.workdir, stdin=p1.stdout, stderr=DEVNULL)
+                p1.stdout.close()
+                p2.communicate()
+                subprocess.run(samtools_sort_cmd(unsortBAM, os.path.join(args.workdir, blobBAM), bamthreads), stderr=DEVNULL)
+                SafeRemove(unsortBAM)
 
-                subprocess.run(["samtools", "index", os.path.join(args.workdir, blobBAM)], stderr=DEVNULL)
+            subprocess.run(["samtools", "index", os.path.join(args.workdir, blobBAM)], stderr=DEVNULL)
 
         # now calculate coverage from BAM file
         status("Calculating read coverage per contig")

--- a/AAFTF/sourpurge.py
+++ b/AAFTF/sourpurge.py
@@ -62,6 +62,7 @@ def run(parser, args):
             else:
                 status(f"$AAFTF_DB/{dbfile} not found, pass --sourdb")
                 sys.exit(1)
+        args.AAFTF_DB = DB
         SOUR = os.path.join(DB, dbfile)
         if not os.path.isfile(SOUR):
             try:

--- a/AAFTF/utility.py
+++ b/AAFTF/utility.py
@@ -152,9 +152,10 @@ def fastastats(input):
 
 def countfastq(input):
     """Count the number of records in a FASTQ file (gzip or regular)."""
-    lines = sum(1 for line in zopen(input))
-    count = int(lines) // 4
-    return count
+    opener = gzip.open if input.endswith(".gz") else open
+    with opener(input, "rt") as fh:
+        lines = sum(1 for _ in fh)
+    return lines // 4
 
 
 def softwrap(string, every=80):

--- a/AAFTF/utility.py
+++ b/AAFTF/utility.py
@@ -368,14 +368,20 @@ def which(program):
 
 
 def open_pipe(command, mode="r", buff=1024 * 1024):
-    """Open read or write pipe to program."""
+    """Open read or write pipe to program.
+
+    `command` may be an argv list (run directly, no shell) or a string
+    (run via the shell) -- the string form exists for `zopen()`'s "!"
+    passthrough where the caller explicitly supplies a shell command.
+    """
     import signal
     import subprocess
 
+    shell = isinstance(command, str)
     if "r" in mode:
-        return subprocess.Popen(command, shell=True, bufsize=buff, stdout=subprocess.PIPE, preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL)).stdout
+        return subprocess.Popen(command, shell=shell, bufsize=buff, stdout=subprocess.PIPE, preexec_fn=lambda: signal.signal(signal.SIGPIPE, signal.SIG_DFL)).stdout
     elif "w" in mode:
-        return subprocess.Popen(command, shell=True, bufsize=buff, stdin=subprocess.PIPE).stdin
+        return subprocess.Popen(command, shell=shell, bufsize=buff, stdin=subprocess.PIPE).stdin
     return None
 
 
@@ -391,6 +397,8 @@ WHICH_PIGZ = which("pigz")
 
 def open_gz(filename, mode="r", buff=1024 * 1024, external=PARALLEL):
     """Open a gzip file using processes (gzip/pigz) or native library."""
+    import subprocess
+
     if external is None or external == NORMAL:
         import gzip
 
@@ -399,16 +407,18 @@ def open_gz(filename, mode="r", buff=1024 * 1024, external=PARALLEL):
         if not WHICH_GZIP:
             return open_gz(filename, mode, buff, NORMAL)
         if "r" in mode:
-            return open_pipe("gzip -dc " + filename, mode, buff)
+            return open_pipe([WHICH_GZIP, "-dc", filename], mode, buff)
         elif "w" in mode:
-            return open_pipe("gzip >" + filename, mode, buff)
+            outfh = open(filename, "wb")
+            return subprocess.Popen([WHICH_GZIP], shell=False, bufsize=buff, stdin=subprocess.PIPE, stdout=outfh).stdin
     elif external == PARALLEL:
         if not WHICH_PIGZ:
             return open_gz(filename, mode, buff, PROCESS)
         if "r" in mode:
-            return open_pipe("pigz -dc " + filename, mode, buff)
+            return open_pipe([WHICH_PIGZ, "-dc", filename], mode, buff)
         elif "w" in mode:
-            return open_pipe("pigz >" + filename, mode, buff)
+            outfh = open(filename, "wb")
+            return subprocess.Popen([WHICH_PIGZ], shell=False, bufsize=buff, stdin=subprocess.PIPE, stdout=outfh).stdin
     return None
 
 

--- a/AAFTF/utility.py
+++ b/AAFTF/utility.py
@@ -398,28 +398,23 @@ WHICH_PIGZ = which("pigz")
 
 def open_gz(filename, mode="r", buff=1024 * 1024, external=PARALLEL):
     """Open a gzip file using processes (gzip/pigz) or native library."""
-    import subprocess
+    import gzip
+
+    if "w" in mode:
+        return gzip.open(filename, mode)
 
     if external is None or external == NORMAL:
-        import gzip
-
         return gzip.GzipFile(filename, mode, buff)
     elif external == PROCESS:
         if not WHICH_GZIP:
             return open_gz(filename, mode, buff, NORMAL)
         if "r" in mode:
             return open_pipe([WHICH_GZIP, "-dc", filename], mode, buff)
-        elif "w" in mode:
-            outfh = open(filename, "wb")
-            return subprocess.Popen([WHICH_GZIP], shell=False, bufsize=buff, stdin=subprocess.PIPE, stdout=outfh).stdin
     elif external == PARALLEL:
         if not WHICH_PIGZ:
             return open_gz(filename, mode, buff, PROCESS)
         if "r" in mode:
             return open_pipe([WHICH_PIGZ, "-dc", filename], mode, buff)
-        elif "w" in mode:
-            outfh = open(filename, "wb")
-            return subprocess.Popen([WHICH_PIGZ], shell=False, bufsize=buff, stdin=subprocess.PIPE, stdout=outfh).stdin
     return None
 
 

--- a/AAFTF/vecscreen.py
+++ b/AAFTF/vecscreen.py
@@ -151,8 +151,10 @@ def parse_clean_blastn(fastafile, prefix, blastn, stringent, contigs_to_remove=N
                         if loc[1] > FiveEnd:
                             FiveEnd = loc[1]
                     elif terminal and pos == "3":
-                        if loc[0] < ThreeEnd:
-                            ThreeEnd = loc[0]
+                        # loc[0] (qstart) is 1-based; the slice end must be
+                        # one less so the first vector/contaminant base isn't kept.
+                        if loc[0] - 1 < ThreeEnd:
+                            ThreeEnd = loc[0] - 1
                     else:  # internal hits to add to list
                         if loc not in internals:
                             internals.append(loc)
@@ -164,7 +166,11 @@ def parse_clean_blastn(fastafile, prefix, blastn, stringent, contigs_to_remove=N
                 else:
                     slicer = [FiveEnd]
                     for x in sInt:
-                        slicer = slicer + x
+                        # x[0] (qstart) is 1-based and used as a slice end below,
+                        # so shift by one to avoid retaining the first hit base.
+                        # x[1] (qend) is used as the following slice start, which
+                        # is already correct as-is.
+                        slicer = slicer + [x[0] - 1, x[1]]
                     slicer.append(ThreeEnd)
                 paired_slicer = list(group(slicer, 2))
                 if len(paired_slicer) < 2:
@@ -298,7 +304,9 @@ def run(parser, args):
                         lastpos = 0
                         newSeq = ""
                         for i, x in enumerate(regions):
-                            newSeq = Seq[lastpos : x[0]]
+                            # x[0] is a 1-based BLAST start; subtract one so the
+                            # slice end doesn't retain the first contaminant base.
+                            newSeq = Seq[lastpos : x[0] - 1]
                             lastpos = x[1]
                             cleanout.write(f">split{i}_{record.id}\n{softwrap(newSeq)}\n")
                             if i == len(regions) - 1:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,6 +33,7 @@ See [AGENTS.md](AGENTS.md) for full development guidelines, code style, and comm
 | `depth` | `coverage`, `cov` | `AAFTF/depth.py` | minimap2, bwa, samtools, mosdepth |
 | `mito` | `mito_asm`, `mitochondria` | `AAFTF/mito.py` | NOVOPlasty, minimap2 |
 | `fix_tbl` | `fix` | `AAFTF/fix_tbl.py` | (none) |
+| `download` | `configure`, `install`, `download_db`, `setup` | `AAFTF/download.py` | (none — urllib only) |
 | `pipeline` | — | `AAFTF/pipeline.py` | all of the above |
 
 ## Module `args` Signatures

--- a/tests/test_depth_integration.py
+++ b/tests/test_depth_integration.py
@@ -1,0 +1,353 @@
+"""Integration tests for AAFTF/depth.py.
+
+These tests invoke the *real* external tools (minimap2, bwa, samtools and
+mosdepth) on a small synthetic genome with reads sampled directly from it.
+They exercise the actual mapping + coverage pipeline end-to-end rather than
+the pure-Python parsing covered by tests/test_depth.py.
+
+The synthetic genome contains four "nuclear" contigs sampled to ~30x and one
+short "organelle" contig sampled to ~400x, so outlier detection has a real
+high-depth contig to find.
+
+Run with:
+    pixi run pytest tests/test_depth_integration.py -m integration -v
+
+Tests are skipped automatically when the required tools are not on PATH, so
+the suite still passes in a bare environment.
+"""
+
+import gzip
+import random
+import shutil
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from AAFTF import depth
+
+pytestmark = pytest.mark.integration
+
+# ---------------------------------------------------------------------------
+# Tool availability — skip the whole module if the core tools are missing
+# ---------------------------------------------------------------------------
+
+_have_minimap2 = shutil.which("minimap2") is not None
+_have_samtools = shutil.which("samtools") is not None
+_have_mosdepth = shutil.which("mosdepth") is not None
+_have_bwa = shutil.which("bwa") is not None
+
+_missing = [
+    name
+    for name, present in (
+        ("minimap2", _have_minimap2),
+        ("samtools", _have_samtools),
+        ("mosdepth", _have_mosdepth),
+    )
+    if not present
+]
+
+requires_tools = pytest.mark.skipif(
+    bool(_missing),
+    reason="missing required tools: " + ", ".join(_missing),
+)
+requires_bwa = pytest.mark.skipif(not _have_bwa, reason="bwa not in PATH")
+
+# ---------------------------------------------------------------------------
+# Synthetic genome / reads
+# ---------------------------------------------------------------------------
+
+# Contigs: (name, length_bp, target_mean_depth)
+# Many nuclear contigs at ~30x keep the population SD small enough that the
+# short, high-depth organelle (400x) lands above the mean + 3*SD threshold and
+# is reliably flagged as an outlier.
+_CONTIG_SPEC = [(f"chr{i}", 3000, 30) for i in range(1, 21)]
+_CONTIG_SPEC.append(("organelle", 1000, 400))
+_READ_LEN = 100
+_FRAG_LEN = 300
+
+_COMPLEMENT = str.maketrans("ACGT", "TGCA")
+
+
+def _revcomp(seq):
+    return seq.translate(_COMPLEMENT)[::-1]
+
+
+def _random_seq(rng, length):
+    """Low-complexity-avoiding random ACGT sequence for unique mapping."""
+    return "".join(rng.choice("ACGT") for _ in range(length))
+
+
+def _build_genome_and_reads(out_dir):
+    """Create a synthetic genome plus paired reads sampled from it.
+
+    Returns (genome_path, r1_path, r2_path).  Reads are exact substrings of
+    the genome (FR orientation) so they map near-perfectly with minimap2 -ax sr.
+    """
+    rng = random.Random(1234)
+
+    genome = {}
+    for name, length, _depth in _CONTIG_SPEC:
+        genome[name] = _random_seq(rng, length)
+
+    genome_path = out_dir / "genome.fasta"
+    with open(genome_path, "w") as fh:
+        for name, _length, _depth in _CONTIG_SPEC:
+            seq = genome[name]
+            fh.write(f">{name}\n")
+            for i in range(0, len(seq), 70):
+                fh.write(seq[i : i + 70] + "\n")
+
+    # Build read pairs from fragments to hit the target per-contig depth.
+    r1_records = []
+    r2_records = []
+    read_idx = 0
+    for name, length, target_depth in _CONTIG_SPEC:
+        seq = genome[name]
+        n_frags = max(1, target_depth * length // (2 * _READ_LEN))
+        max_start = length - _FRAG_LEN
+        for _ in range(n_frags):
+            start = rng.randint(0, max_start)
+            frag = seq[start : start + _FRAG_LEN]
+            fwd = frag[:_READ_LEN]
+            rev = _revcomp(frag[-_READ_LEN:])
+            qual = "I" * _READ_LEN
+            r1_records.append(f"@read{read_idx}/1\n{fwd}\n+\n{qual}\n")
+            r2_records.append(f"@read{read_idx}/2\n{rev}\n+\n{qual}\n")
+            read_idx += 1
+
+    r1_path = out_dir / "reads_R1.fq.gz"
+    r2_path = out_dir / "reads_R2.fq.gz"
+    with gzip.open(r1_path, "wt") as fh:
+        fh.write("".join(r1_records))
+    with gzip.open(r2_path, "wt") as fh:
+        fh.write("".join(r2_records))
+
+    return genome_path, r1_path, r2_path
+
+
+@pytest.fixture(scope="module")
+def synthetic_data(tmp_path_factory):
+    """Module-scoped synthetic genome + reads (built once, reused by tests)."""
+    out_dir = tmp_path_factory.mktemp("depth_synth")
+    genome, r1, r2 = _build_genome_and_reads(out_dir)
+    return Namespace(genome=str(genome), r1=str(r1), r2=str(r2))
+
+
+def _depth_args(synthetic_data, tmp_path, **overrides):
+    """Build a complete Namespace for depth.run() with sensible defaults."""
+    defaults = dict(
+        input=synthetic_data.genome,
+        left=synthetic_data.r1,
+        right=synthetic_data.r2,
+        longreads=None,
+        illumina_preset="sr",
+        longread_preset="map-ont",
+        aligner="minimap2",
+        cpus=2,
+        workdir=str(tmp_path / "workdir"),
+        out=str(tmp_path / "coverage_stats.txt"),
+        min_contig_len=500,
+        no_plot=True,
+        plot_format="pdf",
+        quantize=depth._DEFAULT_QUANTIZE,
+        quantize_labels=None,
+        debug=False,
+        pipe=True,
+    )
+    defaults.update(overrides)
+    return Namespace(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Low-level pipeline functions against real tool output
+# ---------------------------------------------------------------------------
+
+
+@requires_tools
+class TestMapReadsReal:
+    def test_produces_sorted_indexed_bam(self, synthetic_data, tmp_path):
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        bam_ill, bam_lr, bam_combined = depth.map_reads(
+            genome=synthetic_data.genome,
+            reads_left=synthetic_data.r1,
+            reads_right=synthetic_data.r2,
+            longreads=None,
+            workdir=str(workdir),
+            cpus=2,
+            illumina_preset="sr",
+            longread_preset="map-ont",
+            aligner="minimap2",
+            debug=False,
+        )
+        assert bam_lr is None
+        assert bam_combined == bam_ill
+        assert Path(bam_combined).exists()
+        assert Path(bam_combined).stat().st_size > 0
+        assert Path(bam_combined + ".bai").exists()
+
+    def test_flagstat_reports_high_mapping_rate(self, synthetic_data, tmp_path):
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        _, _, bam = depth.map_reads(
+            genome=synthetic_data.genome,
+            reads_left=synthetic_data.r1,
+            reads_right=synthetic_data.r2,
+            longreads=None,
+            workdir=str(workdir),
+            cpus=2,
+            illumina_preset="sr",
+            longread_preset="map-ont",
+            aligner="minimap2",
+            debug=False,
+        )
+        flagstat = depth.run_flagstat(bam)
+        assert "mapped" in flagstat
+        # reads are exact genome substrings: mapping rate should be near 100%
+        line = next(ln for ln in flagstat.splitlines() if "mapped (" in ln)
+        pct = float(line.split("(")[1].split("%")[0])
+        assert pct > 95.0, f"mapping rate unexpectedly low: {line}"
+
+
+@requires_tools
+class TestMosdepthReal:
+    def test_summary_lists_all_contigs(self, synthetic_data, tmp_path):
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        _, _, bam = depth.map_reads(
+            genome=synthetic_data.genome,
+            reads_left=synthetic_data.r1,
+            reads_right=synthetic_data.r2,
+            longreads=None,
+            workdir=str(workdir),
+            cpus=2,
+            illumina_preset="sr",
+            longread_preset="map-ont",
+            aligner="minimap2",
+            debug=False,
+        )
+        summary = depth.run_mosdepth(bam, str(workdir), cpus=2)
+        assert Path(summary).exists()
+        total, contigs = depth.parse_mosdepth_summary(summary)
+        names = {c["chrom"] for c in contigs}
+        assert {"chr1", "chr2", "chr3", "organelle"}.issubset(names)
+        assert total is not None
+        assert total["mean"] > 0
+
+    def test_organelle_has_higher_depth(self, synthetic_data, tmp_path):
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        _, _, bam = depth.map_reads(
+            genome=synthetic_data.genome,
+            reads_left=synthetic_data.r1,
+            reads_right=synthetic_data.r2,
+            longreads=None,
+            workdir=str(workdir),
+            cpus=2,
+            illumina_preset="sr",
+            longread_preset="map-ont",
+            aligner="minimap2",
+            debug=False,
+        )
+        summary = depth.run_mosdepth(bam, str(workdir), cpus=2)
+        _, contigs = depth.parse_mosdepth_summary(summary)
+        by_name = {c["chrom"]: c["mean"] for c in contigs}
+        nuclear_mean = sum(by_name[c] for c in ("chr1", "chr2", "chr3")) / 3
+        # organelle was sampled to ~400x vs ~30x nuclear → clear separation
+        assert by_name["organelle"] > 3 * nuclear_mean
+
+    def test_quantized_mode_writes_bed(self, synthetic_data, tmp_path):
+        workdir = tmp_path / "wd"
+        workdir.mkdir()
+        _, _, bam = depth.map_reads(
+            genome=synthetic_data.genome,
+            reads_left=synthetic_data.r1,
+            reads_right=synthetic_data.r2,
+            longreads=None,
+            workdir=str(workdir),
+            cpus=2,
+            illumina_preset="sr",
+            longread_preset="map-ont",
+            aligner="minimap2",
+            debug=False,
+        )
+        labels, env_dict = depth._parse_quantize_bins(depth._DEFAULT_QUANTIZE)
+        summary, bed = depth.run_mosdepth_quantized(bam, str(workdir), cpus=2, quantize_str=depth._DEFAULT_QUANTIZE, env_dict=env_dict)
+        assert Path(summary).exists()
+        assert Path(bed).exists()
+        contig_data = depth._read_quantized_bed(bed)
+        assert "chr1" in contig_data
+        # every interval label must come from our requested label set
+        seen = {lbl for ivs in contig_data.values() for _, _, lbl in ivs}
+        assert seen.issubset(set(labels))
+
+
+# ---------------------------------------------------------------------------
+# Full depth.run() end-to-end
+# ---------------------------------------------------------------------------
+
+
+@requires_tools
+class TestDepthRunEndToEnd:
+    def test_report_written_with_expected_sections(self, synthetic_data, tmp_path):
+        args = _depth_args(synthetic_data, tmp_path)
+        depth.run(None, args)
+
+        report = Path(args.out)
+        assert report.exists() and report.stat().st_size > 0
+        text = report.read_text()
+        assert "AAFTF Coverage Statistics Report" in text
+        assert "Whole-Assembly Coverage" in text
+        assert "Per-Contig Coverage" in text
+        for contig in ("chr1", "chr2", "chr3", "organelle"):
+            assert contig in text
+
+    def test_organelle_flagged_as_outlier(self, synthetic_data, tmp_path):
+        args = _depth_args(synthetic_data, tmp_path)
+        depth.run(None, args)
+        text = Path(args.out).read_text()
+        # The organelle contig line should carry the OUTLIER flag.
+        organelle_line = next(ln for ln in text.splitlines() if ln.strip().startswith("organelle"))
+        assert "OUTLIER" in organelle_line, organelle_line
+
+    def test_coverage_breadth_near_complete(self, synthetic_data, tmp_path):
+        args = _depth_args(synthetic_data, tmp_path)
+        depth.run(None, args)
+        text = Path(args.out).read_text()
+        breadth_line = next((ln for ln in text.splitlines() if "Bases covered" in ln), None)
+        assert breadth_line is not None
+        pct = float(breadth_line.split(":")[1].strip().rstrip("%"))
+        assert pct > 95.0, breadth_line
+
+    def test_workdir_removed_when_not_debug(self, synthetic_data, tmp_path, monkeypatch):
+        # No explicit workdir → run() creates a uuid temp dir in CWD and is
+        # expected to remove it when not in debug mode.  chdir into tmp_path so
+        # the auto-created dir never lands in the repo.
+        monkeypatch.chdir(tmp_path)
+        args = _depth_args(synthetic_data, tmp_path, workdir=None)
+        depth.run(None, args)
+        assert Path(args.out).exists()
+        leaked = list(tmp_path.glob("aaftf-depth_*"))
+        assert not leaked, f"workdir not cleaned up: {leaked}"
+
+    @pytest.mark.skipif(not depth.HAS_MATPLOTLIB, reason="matplotlib not installed")
+    def test_plots_generated_when_enabled(self, synthetic_data, tmp_path):
+        args = _depth_args(synthetic_data, tmp_path, no_plot=False, plot_format="png")
+        depth.run(None, args)
+        prefix = depth._get_plot_prefix(args.input, args.out)
+        assert Path(prefix + ".depth_heatmap.png").exists()
+        assert Path(prefix + ".depth_barplot.png").exists()
+        assert Path(prefix + ".depth_histogram.png").exists()
+
+
+@requires_tools
+@requires_bwa
+class TestDepthRunBwaAligner:
+    def test_bwa_aligner_produces_report(self, synthetic_data, tmp_path):
+        args = _depth_args(synthetic_data, tmp_path, aligner="bwa")
+        depth.run(None, args)
+        report = Path(args.out)
+        assert report.exists() and report.stat().st_size > 0
+        text = report.read_text()
+        assert "organelle" in text

--- a/tests/test_polish.py
+++ b/tests/test_polish.py
@@ -21,9 +21,6 @@ import pytest
 
 from AAFTF.AAFTF_main import main
 
-pytestmark = pytest.mark.unit
-
-
 # ---------------------------------------------------------------------------
 # Helper: parse 'AAFTF polish ...' without executing the tool
 # ---------------------------------------------------------------------------
@@ -74,6 +71,7 @@ def _make_args(tmp_path, method="pilon", **overrides):
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 class TestPolishParser:
     def test_debug_false_by_default(self):
         args = _parse_polish(["AAFTF", "polish", "-i", "asm.fa", "-l", "R1.fq"])
@@ -189,6 +187,7 @@ class TestPolishParser:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 class TestPolishRunGuards:
     def test_racon_without_longreads_exits(self, tmp_path):
         args = _make_args(tmp_path, method="racon", longreads=None, left=None, right=None)
@@ -256,6 +255,7 @@ def _setup_polca_run(tmp_path, outfile=None):
     )
 
 
+@pytest.mark.unit
 class TestPolishPolcaFailure:
     def test_nonzero_exit_raises_systemexit(self, tmp_path):
         args = _setup_polca_run(tmp_path)
@@ -395,6 +395,7 @@ class TestPolishPolcaFailure:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.unit
 class TestPolishPilonConvergence:
     def test_stops_after_zero_changes(self, tmp_path):
         """Pilon loop breaks at iteration 1 when the .changes file is empty."""
@@ -426,10 +427,14 @@ class TestPolishPilonConvergence:
             (workdir / "polished1.changes").write_text("")
             return mock_result
 
+        def _fake_make_bwa_bam(*a, **kw):
+            (workdir / "asm.bwa.bam").write_text("")
+            return "asm.bwa.bam"
+
         from AAFTF.polish import run
 
         with patch("AAFTF.polish.subprocess.run", side_effect=_fake_run):
-            with patch("AAFTF.polish.make_bwa_bam", return_value="asm.bwa.bam"):
+            with patch("AAFTF.polish.make_bwa_bam", side_effect=_fake_make_bwa_bam):
                 run(None, args)
 
         # Only one pilon invocation — converged at iteration 1
@@ -469,10 +474,14 @@ class TestPolishPilonConvergence:
             (workdir / f"polished{i}.changes").write_text("change\n" * n_changes)
             return mock_result
 
+        def _fake_make_bwa_bam(*a, **kw):
+            (workdir / "asm.bwa.bam").write_text("")
+            return "asm.bwa.bam"
+
         from AAFTF.polish import run
 
         with patch("AAFTF.polish.subprocess.run", side_effect=_fake_run):
-            with patch("AAFTF.polish.make_bwa_bam", return_value="asm.bwa.bam"):
+            with patch("AAFTF.polish.make_bwa_bam", side_effect=_fake_make_bwa_bam):
                 run(None, args)
 
         assert call_count[0] == 2


### PR DESCRIPTION
## Summary

Fixes 13 findings from a full-codebase review (consistency/security/efficiency + bioinformatics correctness), covering three areas:

**Pipeline correctness (Critical)**
- `pipeline.py`: the `polish` step's Namespace never set `args.method` (or `diploid`/`ploidy`/`polca`/`longreads`), so `AAFTF pipeline` crashed with `AttributeError` before polishing could start on every run.
- `pipeline.py`: `right`/`screen_local` were only added to child Namespaces when truthy, but target modules read them unconditionally — crashed on single-end runs or when mito assembly was skipped. Now always set explicitly (`None` when absent).
- `rmdup.py`: the duplicate-contig identity/coverage threshold check was nested inside `if args.debug:`, so duplicate-contig removal silently never ran in normal (non-debug) use.
- `sourpurge.py`: the BWA alignment block that builds the coverage BAM was nested inside `if revReads:`, so single-end runs never got a BAM and later hit `ZeroDivisionError` on empty coverage data.
- `sourpurge.py`: `UnboundLocalError` when `$AAFTF_DB` is unset and `--AAFTF_DB` is passed instead — `DB` was never bound before an unconditional use.

**Security**
- `utility.py`: `open_pipe`/`open_gz` built `gzip`/`pigz` commands via `shell=True` string concatenation (`"pigz -dc " + filename`), letting shell metacharacters in a filename run arbitrary commands. Reachable from `countfastq()` on user-supplied FASTQ paths. Switched to argv lists with `shell=False`.

**Coordinate/domain correctness (bioinformatics)**
- `assess.py`: forward-strand telomere search hardcoded the repeat count to 2 instead of honoring `--telomere_n_repeat`, biasing FWD vs REV telomere stats.
- `vecscreen.py`: BLAST's 1-based `qstart` used directly as a Python slice-end (missing `-1`) at three trim sites, retaining one stray base of every vector/contaminant hit.
- `mito.py`: a negative/out-of-range rotation offset from a partial seed alignment silently wrapped via Python negative-index slicing instead of erroring, producing a plausible but incorrectly rotated mitochondrial genome.

**Consistency/efficiency (minor)**
- `AAFTF_main.py`/`CLAUDE.md`: `download` subcommand was missing the `-v/--debug`/`--pipe` flags every other subcommand has; added them and documented `download` in the subcommand reference table.
- `sort.py`: assembly FASTA was parsed twice (once for lengths, again via `SeqIO.to_dict()` for sequences); now single-pass.
- `utility.py`/`depth.py`: consolidated two duplicate FASTQ-counting implementations onto one plain `gzip.open`/`open` loop.
- `depth.py`: added a `-R` read-group tag to the `bwa mem` invocation for consistency with the rest of the file's careful flag handling.

## Test plan
- [x] `python -m py_compile` on all changed modules
- [x] `pytest tests/ -m unit -q` — 366 passed, 3 skipped, same 6 pre-existing failures on `main` (missing `bwa`/`pilon` binaries in this env, unrelated to these changes)
- [x] Manually traced the vecscreen off-by-one fix against constructed sequences (terminal, internal, and combined cases) to confirm correct boundaries
- [x] Manual smoke test of `sort.py` single-pass rewrite (ordering, minlen filtering, sequence correctness)
- [x] `ruff check` clean on all modified files; pre-commit hooks passed on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)